### PR TITLE
fix: show recipe title in normal font and hide share button when prin…

### DIFF
--- a/style.css
+++ b/style.css
@@ -1342,7 +1342,8 @@ main {
     .settings-backdrop,
     .settings-panel,
     .back-btn,
-    .print-btn {
+    .print-btn,
+    .share-btn {
         display: none !important;
     }
 
@@ -1376,8 +1377,18 @@ main {
         align-items: flex-start;
     }
 
-    /* Recipe title */
+    /* Recipe title - show the back-btn in recipe header so title is visible */
+    .recipe-header .back-btn {
+        display: flex !important;
+        padding: 0 !important;
+    }
+
+    .recipe-header .back-btn svg {
+        display: none !important;
+    }
+
     .recipe-title-header {
+        font-family: var(--font-body) !important;
         font-size: 19pt !important;
         font-weight: 700 !important;
         color: black !important;


### PR DESCRIPTION
…ting

- Show recipe header back-btn in print mode (but hide the arrow icon) so the title is visible
- Add font-family override in print styles to use body font instead of decorative logo font for the recipe title
- Add .share-btn to the list of hidden elements in print mode

https://claude.ai/code/session_01G268KStV4Jif5LRcdPUpnG