### PR TITLE
fix: use smart back navigation instead of browser history

### DIFF
--- a/script.js
+++ b/script.js
@@ -34,6 +34,7 @@ Vue.createApp({
       hideShareButton: false,
       checkedIngredients: [],
       checkedSteps: [],
+      prevRoute: null, // Tracks where user came from for smart back navigation
     };
   },
   async created() {
@@ -305,12 +306,51 @@ Vue.createApp({
       this.clearChecked();
     },
     showRecipe(recipe) {
+      // Save where we came from for smart back navigation
+      if (this.current === 'search') {
+        this.prevRoute = { type: 'search', query: this.searchQuery };
+      } else if (this.current === 'category' && this.activeCategory !== null) {
+        this.prevRoute = { type: 'category', index: this.activeCategory };
+      } else {
+        this.prevRoute = null;
+      }
       this.showRecipeNoHash(recipe);
       window.location.hash = "#/recipe/" + this.slugify(recipe.title);
       window.scrollTo(0, 0);
     },
     goBack() {
-      window.history.back();
+      if (this.current === 'recipe') {
+        // If we know where we came from, go back there
+        if (this.prevRoute) {
+          if (this.prevRoute.type === 'search') {
+            this.searchQuery = this.prevRoute.query;
+            this.showSearch = true;
+            this.search();
+            return;
+          }
+          if (this.prevRoute.type === 'category') {
+            const idx = this.prevRoute.index;
+            if (idx >= 0 && idx < this.categories.length) {
+              this.toggle(this.categories[idx], idx);
+              return;
+            }
+          }
+        }
+        // Fallback for direct links: go to recipe's category or home
+        const recipe = this.original.find(r => r.title === this.rtitle);
+        if (recipe && recipe.category) {
+          const catIndex = this.categories.findIndex(c => c.name === recipe.category);
+          if (catIndex !== -1) {
+            this.toggle(this.categories[catIndex], catIndex);
+            return;
+          }
+        }
+        this.home();
+      } else if (this.current === 'category' || this.current === 'search') {
+        this.home();
+      } else {
+        this.home();
+      }
     },
     printRecipe() {
       window.print();

--- a/script.js
+++ b/script.js
@@ -246,6 +246,8 @@ Vue.createApp({
         const slug = parts[1];
         const recipe = this.original.find((r) => this.slugify(r.title) === slug);
         if (recipe) {
+          // Clear prevRoute for URL-based navigation since we don't know the origin
+          this.prevRoute = null;
           this.showRecipeNoHash(recipe);
           return;
         }

--- a/script.js
+++ b/script.js
@@ -336,7 +336,7 @@ Vue.createApp({
             }
           }
         }
-        // Fallback for direct links: go to recipe's category or home
+        // Fallback for direct links: go to recipe's category
         const recipe = this.original.find(r => r.title === this.rtitle);
         if (recipe && recipe.category) {
           const catIndex = this.categories.findIndex(c => c.name === recipe.category);
@@ -345,10 +345,9 @@ Vue.createApp({
             return;
           }
         }
-        this.home();
-      } else {
-        this.home();
       }
+      // Default: go home
+      this.home();
     },
     printRecipe() {
       window.print();

--- a/script.js
+++ b/script.js
@@ -346,8 +346,6 @@ Vue.createApp({
           }
         }
         this.home();
-      } else if (this.current === 'category' || this.current === 'search') {
-        this.home();
       } else {
         this.home();
       }


### PR DESCRIPTION
Replace window.history.back() with intelligent navigation that keeps users within the app:

- From recipe: returns to the view they came from (search results or category), or falls back to the recipe's category for direct links
- From category/search: returns to home

This fixes the issue where clicking back after opening a shared recipe link would exit the app entirely instead of navigating within it.

Edge cases handled:
- Direct link to recipe → back → recipe's category (or home)
- Direct link to category → back → home
- Direct link to search → back → home
- Category → recipe → back → same category
- Search → recipe → back → search results with same query
- Recipe with unknown category → back → home

https://claude.ai/code/session_01G268KStV4Jif5LRcdPUpnG