### PR TITLE
Add red accent color option

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,8 @@
                             @click="setAccentColor('blue')" aria-label="Blue accent"></button>
                         <button class="color-swatch green" :class="{ active: accentColor === 'green' }"
                             @click="setAccentColor('green')" aria-label="Green accent"></button>
+                        <button class="color-swatch red" :class="{ active: accentColor === 'red' }"
+                            @click="setAccentColor('red')" aria-label="Red accent"></button>
                     </div>
                 </div>
                 <div class="setting-group">

--- a/script.js
+++ b/script.js
@@ -138,6 +138,11 @@ Vue.createApp({
           light: { accent: "#74B944", hover: "#65a33b", light: "rgba(116, 185, 68, 0.1)" },
           dark: { accent: "#8BC963", hover: "#74B944", light: "rgba(139, 201, 99, 0.12)" },
         },
+        red: {
+          pill: "#b94444",
+          light: { accent: "#b94444", hover: "#a33b3b", light: "rgba(185, 68, 68, 0.1)" },
+          dark: { accent: "#c96363", hover: "#b94444", light: "rgba(201, 99, 99, 0.12)" },
+        },
       };
       const theme = this.theme === "system"
         ? (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light")

--- a/style.css
+++ b/style.css
@@ -467,6 +467,10 @@ input {
     background: #74B944;
 }
 
+.color-swatch.red {
+    background: #b94444;
+}
+
 /* Text Size Slider */
 .text-size-control {
     display: flex;


### PR DESCRIPTION
## Summary
- Adds a new **red** accent color option alongside the existing blue and green choices
- Includes light and dark theme variants with appropriate hover states
- Adds the red color swatch button to the settings panel

## Test plan
- [ ] Open settings and verify the red swatch appears next to blue and green
- [ ] Click the red swatch and confirm the UI updates to use red accents
- [ ] Toggle between light and dark themes to verify red variants look correct
- [ ] Refresh the page and confirm the red accent selection persists